### PR TITLE
Update Judikatur.py

### DIFF
--- a/risApiWrapper/Judikatur.py
+++ b/risApiWrapper/Judikatur.py
@@ -1163,23 +1163,44 @@ def _convert_results(raw_results: list) -> list:
             converted_case["document_url"] = None
 
         try:
-            # Not sure about this change, but worked for me...
-            # Sometimes multiple attachments are assigned. One must deal with such lists.
-            #--> See for example: 4Ob72/21y
-            converted_case["content_urls"] = {}
-            if (isinstance(raw_case["Data"]["Dokumentliste"]["ContentReference"], dict)):
-                for url in raw_case["Data"]["Dokumentliste"]["ContentReference"][
-                    "Urls"
-                ]["ContentUrl"]:
-                    converted_case["content_urls"][url["DataType"]] = url["Url"]
+            # Sometimes (like 4Ob72/21y) multiple types of contents are
+            # provided which results in "ContentReference" containing a list.
+            converted_case["content_urls"] = []
+            if isinstance(
+                raw_case["Data"]["Dokumentliste"]["ContentReference"], dict
+            ):
+                for url in raw_case["Data"]["Dokumentliste"][
+                    "ContentReference"]["Urls"]["ContentUrl"]:
+                    converted_case["content_urls"].append(
+                        {
+                            "Name": raw_case["Data"]["Dokumentliste"][
+                                "ContentReference"]["Name"],
+                            "Datatype": url["DataType"],
+                            "Url": url["Url"],
+                        }
+                    )
             else:
-                else: # if there are lists of attachments one must deal with them 
-                    for element in raw_case["Data"]["Dokumentliste"]["ContentReference"]:
-                        if (isinstance(element["Urls"]["ContentUrl"], dict)):
-                          converted_case["content_urls"][element["Name"]]  = element["Urls"]["ContentUrl"]["Url"]
-                        else:
-                            for url in element["Urls"]["ContentUrl"]:
-                                converted_case["content_urls"][url["DataType"]] = url["Url"]
+                for element in raw_case["Data"]["Dokumentliste"][
+                    "ContentReference"]:
+                    if isinstance(element["Urls"]["ContentUrl"], dict):
+                        converted_case["content_urls"].append(
+                            {
+                                "Name": element["Name"],
+                                "Datatype": element["Urls"]["ContentUrl"][
+                                    "DataType"],
+                                "Url": element["Urls"]["ContentUrl"]["Url"],
+                            }
+                        )
+
+                    else:
+                        for url in element["Urls"]["ContentUrl"]:
+                            converted_case["content_urls"].append(
+                                {
+                                    "Name": element["Name"],
+                                    "Datatype": url["DataType"],
+                                    "Url": url["Url"],
+                                }
+                            )
         except KeyError:
             converted_case["content_urls"] = None
 

--- a/risApiWrapper/Judikatur.py
+++ b/risApiWrapper/Judikatur.py
@@ -1163,11 +1163,23 @@ def _convert_results(raw_results: list) -> list:
             converted_case["document_url"] = None
 
         try:
+            # Not sure about this change, but worked for me...
+            # Sometimes multiple attachments are assigned. One must deal with such lists.
+            #--> See for example: 4Ob72/21y
             converted_case["content_urls"] = {}
-            for url in raw_case["Data"]["Dokumentliste"]["ContentReference"][
-                "Urls"
-            ]["ContentUrl"]:
-                converted_case["content_urls"][url["DataType"]] = url["Url"]
+            if (isinstance(raw_case["Data"]["Dokumentliste"]["ContentReference"], dict)):
+                for url in raw_case["Data"]["Dokumentliste"]["ContentReference"][
+                    "Urls"
+                ]["ContentUrl"]:
+                    converted_case["content_urls"][url["DataType"]] = url["Url"]
+            else:
+                else: # if there are lists of attachments one must deal with them 
+                    for element in raw_case["Data"]["Dokumentliste"]["ContentReference"]:
+                        if (isinstance(element["Urls"]["ContentUrl"], dict)):
+                          converted_case["content_urls"][element["Name"]]  = element["Urls"]["ContentUrl"]["Url"]
+                        else:
+                            for url in element["Urls"]["ContentUrl"]:
+                                converted_case["content_urls"][url["DataType"]] = url["Url"]
         except KeyError:
             converted_case["content_urls"] = None
 


### PR DESCRIPTION
Not sure about this change, but worked for me
Sometimes there are multiple attachments (e.g 4Ob72/21y). In such case one must deal with these lists. (Maybe a more general approach could be used to do this kind of "result type checking" for every result of the Ris-API).