### PR TITLE
Update Helper.py

### DIFF
--- a/risApiWrapper/Helper.py
+++ b/risApiWrapper/Helper.py
@@ -11,6 +11,13 @@ def _request(url, parameters) -> list:
     """
     response = requests.get(url, params=parameters).json()
 
+    #It could be the case that there are exactly 100 results in the first run
+    # The API throws an error {'OgdSearchResult': {'Error': {'Applikation': 'Bvwg', 'Message': 'soap:Client Die Seitennummer ist höher als die Anzahl der verfügbaren Seiten'}}}
+    # Hence an empty dict needs to be returned
+    if 'OgdDocumentResults' not in response["OgdSearchResult"]:
+        return []
+    
+
     # Return nothing if no items are found
     if int(response["OgdSearchResult"]["OgdDocumentResults"]["Hits"]["#text"]) == 0:
         return []


### PR DESCRIPTION
Fixed _request due to an error that can occur if exactly 100 decisions are found in the first run.
This is the case for BVwG decisions on 13.06.2024
If the error occurs an empty list is returned 